### PR TITLE
DPL-676: Stop serving UAT actions

### DIFF
--- a/middleware/uat_actions.ts
+++ b/middleware/uat_actions.ts
@@ -1,0 +1,13 @@
+const config = useRuntimeConfig()
+
+/*
+Redirect all requests using this middleware to the site root if the UAT Actions navigation item
+is not among the enabled routes.
+ */
+export default defineNuxtRouteMiddleware(() => {
+  const enabledNavItems = selectNavItems(config.enabledNavItems)
+
+  if (!enabledNavItems.find((item: { path: string }) => item.path.startsWith('/uat_actions/'))) {
+    return navigateTo('/')
+  }
+})

--- a/pages/uat_actions/generate_test_run.vue
+++ b/pages/uat_actions/generate_test_run.vue
@@ -216,4 +216,8 @@ export default {
 }
 </script>
 
+<script setup>
+definePageMeta({ middleware: 'uat-actions' })
+</script>
+
 <style scoped lang="scss"></style>

--- a/pages/uat_actions/test_runs/[id].vue
+++ b/pages/uat_actions/test_runs/[id].vue
@@ -109,4 +109,8 @@ export default {
 }
 </script>
 
+<script setup>
+definePageMeta({ middleware: 'uat-actions' })
+</script>
+
 <style scoped lang="scss"></style>

--- a/pages/uat_actions/test_runs/index.vue
+++ b/pages/uat_actions/test_runs/index.vue
@@ -108,4 +108,8 @@ export default {
 }
 </script>
 
+<script setup>
+definePageMeta({ middleware: 'uat-actions' })
+</script>
+
 <style scoped lang="scss"></style>

--- a/test/pages/uat_actions/generate_test_run.spec.js
+++ b/test/pages/uat_actions/generate_test_run.spec.js
@@ -24,8 +24,8 @@ describe('UAT Actions', () => {
     })
 
     it('is not displayed when the maximum plates is reached', async () => {
-      wrapper.vm.maxNumberOfPlates = 2
-      wrapper.vm.plateSpecs = [
+      wrapper.vm.$data.maxNumberOfPlates = 2
+      wrapper.vm.$data.plateSpecs = [
         { numberOfPlates: 1, numberOfPositives: 1 },
         { numberOfPlates: 1, numberOfPositives: 3 },
       ]
@@ -60,10 +60,11 @@ describe('UAT Actions', () => {
   // computed
   describe('totalPlates', () => {
     it('totals the number of plates', () => {
-      wrapper.vm.plateSpecs = [
+      wrapper.vm.$data.plateSpecs = [
         { numberOfPlates: 2, numberOfPositives: 1 },
         { numberOfPlates: 11, numberOfPositives: 3 },
       ]
+
       expect(wrapper.vm.totalPlates).toEqual(2 + 11)
     })
   })
@@ -74,7 +75,8 @@ describe('UAT Actions', () => {
     })
 
     it('when busy', () => {
-      wrapper.vm.status = statuses.Busy
+      wrapper.vm.$data.status = statuses.Busy
+
       expect(wrapper.vm.isBusy).toBeTruthy()
     })
   })
@@ -85,10 +87,11 @@ describe('UAT Actions', () => {
     })
 
     it('when valid', () => {
-      wrapper.vm.plateSpecs = [
+      wrapper.vm.$data.plateSpecs = [
         { numberOfPlates: 2, numberOfPositives: 1 },
         { numberOfPlates: 11, numberOfPositives: 3 },
       ]
+
       expect(wrapper.vm.isValid).toBeTruthy()
     })
   })
@@ -197,9 +200,10 @@ describe('UAT Actions', () => {
   })
 
   describe('#generateTestRun', () => {
-    let wrapper
+    let wrapper, showAlert
 
     beforeEach(() => {
+      showAlert = vi.spyOn(GenerateTestRun.methods, 'showAlert')
       wrapper = mount(GenerateTestRun, {
         data() {
           return {
@@ -207,7 +211,6 @@ describe('UAT Actions', () => {
           }
         },
       })
-      wrapper.vm.showAlert = vi.fn()
     })
 
     it('when the request is successful', async () => {
@@ -217,11 +220,12 @@ describe('UAT Actions', () => {
       })
 
       await wrapper.find('#generateTestRunButton').trigger('click')
+
       expect(lighthouseService.generateTestRun).toHaveBeenCalledWith([
         { numberOfPlates: 1, numberOfPositives: 2 },
       ])
       expect(navigateTo).toHaveBeenCalled()
-      expect(wrapper.vm.showAlert).not.toHaveBeenCalled()
+      expect(showAlert).not.toHaveBeenCalled()
     })
 
     it('when the request fails', async () => {
@@ -231,10 +235,11 @@ describe('UAT Actions', () => {
       })
 
       await wrapper.find('#generateTestRunButton').trigger('click')
+
       expect(lighthouseService.generateTestRun).toHaveBeenCalledWith([
         { numberOfPlates: 1, numberOfPositives: 2 },
       ])
-      expect(wrapper.vm.showAlert).toHaveBeenCalledWith('There was an error', 'danger')
+      expect(showAlert).toHaveBeenCalledWith('There was an error', 'danger')
     })
 
     it('updates the status', async () => {

--- a/test/setup.js
+++ b/test/setup.js
@@ -21,6 +21,7 @@ vi.mock('#app', () => {
       projectId: '5',
       studyId: '10',
       printers: 'a,b,c',
+      enabledNavItems: 'box_buster',
     }),
   }
 })


### PR DESCRIPTION
Closes #23 

Changes proposed in this pull request:

* Add middleware to the UAT Actions routes to prevent serving those pages if the nav item is not enabled for UAT Actions.
