### PR TITLE
Y24-244 - Update checkout dependency to v4

### DIFF
--- a/.github/workflows/automated_release.yml
+++ b/.github/workflows/automated_release.yml
@@ -13,7 +13,7 @@ jobs:
   build_test_and_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: nelonoel/branch-name@v1.0.1
 

--- a/.github/workflows/check_release_version.yml
+++ b/.github/workflows/check_release_version.yml
@@ -10,7 +10,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Get specific changed files
         id: changed-files-specific

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup node
         uses: actions/setup-node@v2
@@ -36,7 +36,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup node
         uses: actions/setup-node@v2
@@ -58,7 +58,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup node
         uses: actions/setup-node@v2

--- a/.github/workflows/docker_dispatch.yml
+++ b/.github/workflows/docker_dispatch.yml
@@ -15,7 +15,7 @@ jobs:
   build_and_publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Build the Docker image
         run: >-


### PR DESCRIPTION
Closes https://github.com/sanger/General-Backlog-Items/issues/433

#### Changes proposed in this pull request

- Bumped `checkout` dependency to v4.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_